### PR TITLE
fix bug where code options > 9 would produce incorrect hidden code

### DIFF
--- a/src/actions/retrieveApi.js
+++ b/src/actions/retrieveApi.js
@@ -13,13 +13,16 @@ export async function getRandomNumbers(size, range) {
     let receivedString = await response.text();
     let numArray = [];
     let countOfEachNum = {};
+    let currentNum = "";
     for (let i = 0; i < receivedString.length; i++) {
-      let currentNum = receivedString[i];
-      let stringToInt = parseInt(currentNum);
-      if (!isNaN(stringToInt)) {
-        //avoid line breaks
+      let currentChar = receivedString[i];
+      if (!isNaN(parseInt(currentChar))) {
+        currentNum += currentChar;
+      } else {
+        let stringToInt = parseInt(currentNum);
         numArray.push(stringToInt);
         countOfEachNum[stringToInt] = countOfEachNum[stringToInt] + 1 || 1;
+        currentNum = "";
       }
     }
     store.dispatch(setCode({ code: numArray, countOfEachNum: countOfEachNum }));


### PR DESCRIPTION
Retrieve code now able to process numbers greater than 9. Previously it would separate double digits into their own single digits.